### PR TITLE
Feature/add ut for save items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "symfony/cache": "^4.2"
     },
     "require-dev": {
+        "doctrine/cache": "^1.8",
         "lmc/coding-standard": "^1.3",
         "phpstan/phpstan-phpunit": "^0.11.0",
         "phpstan/phpstan-shim": "^0.11",
-        "phpunit/phpunit": "^7.5",
-        "doctrine/cache": "^1.8"
+        "phpunit/phpunit": "^7.5"
     },
     "suggest": {
         "doctrine/cache": "Allows use of the DoctrineSymfonyAdapter for the AerospikeCache compatibility with Doctrine Cache"

--- a/tests/AerospikeCacheTest.php
+++ b/tests/AerospikeCacheTest.php
@@ -37,14 +37,14 @@ class AerospikeCacheTest extends AbstractTestCase
         $aerospikeCache = new AerospikeCache($aerospikeMock, 'test', 'cache');
 
         $aerospikeMock->method('put')
-                ->willReturn($aerospikeStatusCode);
+            ->willReturn($aerospikeStatusCode);
 
         $aerospikeMock->method('get')
-                ->willReturn(\Aerospike::OK);
+            ->willReturn(\Aerospike::OK);
 
         $aerospikeKey = ['ns' => 'test', 'set' => 'cache', 'key' => 'foo'];
         $aerospikeMock->method('initKey')
-                ->willReturn($aerospikeKey);
+            ->willReturn($aerospikeKey);
 
         $cacheItem = $aerospikeCache->getItem('foo');
         $saveSuccessful = $aerospikeCache->save($cacheItem);
@@ -71,8 +71,11 @@ class AerospikeCacheTest extends AbstractTestCase
     /**
      * @dataProvider provideStatusCodesForClearingNamespace
      */
-    public function testShouldClearNamespace(int $statusCodeForRemove, int $statusCodeForScan, bool $expectedValue): void
-    {
+    public function testShouldClearNamespace(
+        int $statusCodeForRemove,
+        int $statusCodeForScan,
+        bool $expectedValue
+    ): void {
         $aerospikeMock = $this->createMock(\Aerospike::class);
         $aerospikeCache = new AerospikeCache($aerospikeMock, 'test', 'cache', 'testNamespace');
 
@@ -130,8 +133,10 @@ class AerospikeCacheTest extends AbstractTestCase
     /**
      * @dataProvider doFetchProvider
      */
-    public function testShouldReadExistingRecordsFromAerospike(array $cacheItemKeys, array $valuesReturnedByAerospike): void
-    {
+    public function testShouldReadExistingRecordsFromAerospike(
+        array $cacheItemKeys,
+        array $valuesReturnedByAerospike
+    ): void {
         $mockedAerospikeKeys = array_map(
             function ($key) {
                 return ['ns' => 'aerospike', 'set' => 'cache', 'key' => $key];


### PR DESCRIPTION
This PR is intended to be part of https://github.com/lmc-eu/aerospike-cache-php/pull/2

---

Those first two commits was unplanned, but they happened while I worked on the test.

Test itself checks all wanted scenarious with saving, it is quite more complex then I would assume, but is is IMHO still readable enough.